### PR TITLE
Fix build with vala 0.44

### DIFF
--- a/src/Widgets/MergePDF.vala
+++ b/src/Widgets/MergePDF.vala
@@ -59,7 +59,7 @@ namespace pdftricks {
             view = new Gtk.TreeView.with_model (list_store);
             view.hexpand = true;
             view.vexpand = true;
-            view.enable_model_drag_source( Gdk.BUTTON1_MASK,
+            view.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK,
                                                 targets,
                                                 Gdk.DragAction.MOVE);
             view.enable_model_drag_dest(targets,


### PR DESCRIPTION
This fixes the following error:
```
../pdftricks-0.2.5/src/Widgets/MergePDF.vala:62.44-62.59: error: The name `BUTTON1_MASK' does not exist in the context of `Gdk'
            view.enable_model_drag_source( Gdk.BUTTON1_MASK,
                                           ^^^^^^^^^^^^^^^^
```