### PR TITLE
Fix message dialog about ImageMagick Policies

### DIFF
--- a/src/Widgets/MergePDF.vala
+++ b/src/Widgets/MergePDF.vala
@@ -241,6 +241,10 @@ namespace pdftricks {
                 var file_pdf = (string) cell1;
                 if(!file_pdf.contains(".pdf")){
                     file_pdf = convert_to_pdf(file_pdf);
+                    if (file_pdf == ""){
+                        files_pdf = "";
+                        return true;
+                    }
                 }
                 files_pdf = files_pdf + " " + file_pdf.replace(" ", "\\ ");
                 return false;
@@ -283,7 +287,7 @@ namespace pdftricks {
                 if(output.contains("Error")){
                     return "";
                 }
-                if(stderr.contains("not authorized")){
+                if(stderr.contains("not allowed")){
                     var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (_("ImageMagick Policies"), _("Change the ImageMagick security policies that prevent this operation and try again."), "process-stop", Gtk.ButtonsType.CLOSE);
                     message_dialog.set_transient_for(window);
                     message_dialog.show_all ();


### PR DESCRIPTION
1. The message dialog never displayed, because it expect "not authorized" text, but  the warning message is the following:
```
convert: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/408.
```
2. The message dialog is displayed for each file. After that change it will be displayed only once, and cancel the process.