### PR TITLE
typo replaced "de" with "the" in...

### DIFF
--- a/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
+++ b/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
@@ -15,7 +15,7 @@
       <li>Merge PDF</li>
       <li>Convert PDF</li>
     </ul>
-    <p>In recent versions of ImageMagick has been added a security policy that blocks manipulations in PDF files. This affects PDFTricks operations. To correct this change the settings of your ImageMagick installation. Check de homepage for instructions.</p>
+    <p>In recent versions of ImageMagick has been added a security policy that blocks manipulations in PDF files. This affects PDFTricks operations. To correct this change the settings of your ImageMagick installation. Check the homepage for instructions.</p>
   </description>
   <releases>
     <release version="0.2.7" date="2019-08-13">


### PR DESCRIPTION
...Check de homepage for instructions.