### PR TITLE
Display icon in window list

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -90,7 +90,7 @@ namespace pdftricks {
             stack.add_named (convert_pdf, "convert_pdf");
 
             main_window.application = this;
-            main_window.icon_name = "pdftricks";
+            main_window.icon_name = "com.github.muriloventuroso.pdftricks";
             main_window.title = _("PDF Tricks");
             main_window.add (stack);
             main_window.set_size_request (800, 640);


### PR DESCRIPTION
This PR allows the pdftricks icon to be displayed in window lists, window selectors, ... (MATE Desktop Environment)

Before:
![no_icon](https://user-images.githubusercontent.com/49864414/115589818-99132c80-a2d0-11eb-8314-2072910408d6.png)
After:
![icon](https://user-images.githubusercontent.com/49864414/115589838-9e707700-a2d0-11eb-96b0-5147fe684064.png)



This is done by setting the main_window icon_name form pdftricks to com.github.muriloventuroso.pdftricks so that the icon can be found.

