### PR TITLE
Default save location of compressed pdf to same as the original

### DIFF
--- a/src/Widgets/CompressPDF.vala
+++ b/src/Widgets/CompressPDF.vala
@@ -159,7 +159,7 @@ namespace pdftricks {
                 _("Cancel"));
             var split_filename = file_pdf.split("/");
             var filename = split_filename[split_filename.length - 1];
-            chooser_output.set_current_folder(file_pdf);
+            chooser_output.set_current_folder(Path.get_dirname(file_pdf));
             chooser_output.set_current_name(filename.split(".")[0] + "_compressed.pdf");
             chooser_output.do_overwrite_confirmation = true;
             if (chooser_output.run () == Gtk.ResponseType.ACCEPT) {


### PR DESCRIPTION
When compressing a pdf most users want the compressed pdf to be saved in the same directory. Before this PR the root directory was always set as default by the  filechooser after selecting the compress button. However instead of being forced to always click through your whole filesystem tree to the original location it is now set by default.

Before:
![always_root_dir](https://user-images.githubusercontent.com/49864414/115592835-0b394080-a2d4-11eb-8843-5743cdaa95ff.png)
After:

![use_current_dir](https://user-images.githubusercontent.com/49864414/115592842-0d030400-a2d4-11eb-9270-e08c5863f1d9.png)


This was done by parsing the directory name instead of the filename filename to the `set_current_folder` function (https://valadoc.org/gtk+-3.0/Gtk.FileChooser.set_current_folder.html) using the `get_dirname` function (https://valadoc.org/glib-2.0/GLib.Path.get_dirname.html)
