### PR TITLE
User messages: fix wrong wording in the "merge" and "split" user dialogues

### DIFF
--- a/src/Widgets/MergePDF.vala
+++ b/src/Widgets/MergePDF.vala
@@ -68,7 +68,7 @@ namespace pdftricks {
             view.drag_data_received.connect(on_drag_data_received);
             add_button.clicked.connect(() => {
                 Gtk.FileChooserNative chooser_file = new Gtk.FileChooserNative (
-                _("Select the file to compress"), window, Gtk.FileChooserAction.OPEN,
+                _("Select the file to merge"), window, Gtk.FileChooserAction.OPEN,
                 _("Open"),
                 _("Cancel"));
 
@@ -255,7 +255,7 @@ namespace pdftricks {
             }
             var output_file = "";
             Gtk.FileChooserNative chooser_output = new Gtk.FileChooserNative (
-                _("Select the file to compress"), window, Gtk.FileChooserAction.SAVE,
+                _("Select the file to merge"), window, Gtk.FileChooserAction.SAVE,
                 _("Save"),
                 _("Cancel"));
             chooser_output.do_overwrite_confirmation = true;

--- a/src/Widgets/MergePDF.vala
+++ b/src/Widgets/MergePDF.vala
@@ -255,7 +255,7 @@ namespace pdftricks {
             }
             var output_file = "";
             Gtk.FileChooserNative chooser_output = new Gtk.FileChooserNative (
-                _("Select the file to merge"), window, Gtk.FileChooserAction.SAVE,
+                _("Select the file to save"), window, Gtk.FileChooserAction.SAVE,
                 _("Save"),
                 _("Cancel"));
             chooser_output.do_overwrite_confirmation = true;

--- a/src/Widgets/SplitPDF.vala
+++ b/src/Widgets/SplitPDF.vala
@@ -261,7 +261,7 @@ namespace pdftricks {
             var file_pdf = filechooser.get_filename();
             var output_file = "";
             Gtk.FileChooserNative chooser_output = new Gtk.FileChooserNative (
-                _("Select the file to split"), window, Gtk.FileChooserAction.SAVE,
+                _("Select the file to save"), window, Gtk.FileChooserAction.SAVE,
                 _("Save"),
                 _("Cancel"));
             var split_filename = file_pdf.split("/");

--- a/src/Widgets/SplitPDF.vala
+++ b/src/Widgets/SplitPDF.vala
@@ -45,7 +45,7 @@ namespace pdftricks {
             page_size = 0;
             type_split = "all";
 
-            filechooser = new Gtk.FileChooserButton (_("Select the file to compress"), Gtk.FileChooserAction.OPEN);
+            filechooser = new Gtk.FileChooserButton (_("Select the file to split"), Gtk.FileChooserAction.OPEN);
 
             Gtk.FileFilter filter = new Gtk.FileFilter ();
             filechooser.set_filter (filter);
@@ -261,7 +261,7 @@ namespace pdftricks {
             var file_pdf = filechooser.get_filename();
             var output_file = "";
             Gtk.FileChooserNative chooser_output = new Gtk.FileChooserNative (
-                _("Select the file to compress"), window, Gtk.FileChooserAction.SAVE,
+                _("Select the file to split"), window, Gtk.FileChooserAction.SAVE,
                 _("Save"),
                 _("Cancel"));
             var split_filename = file_pdf.split("/");


### PR DESCRIPTION
This PR fixes wrong wording in the "merge" and "split" user dialogues.

Fixes #79